### PR TITLE
Anti brownout

### DIFF
--- a/commands/Drivetrain/SmartArcadeDrive.java
+++ b/commands/Drivetrain/SmartArcadeDrive.java
@@ -40,6 +40,7 @@ Add connectivity b/x other parts
         SmartDashboard.putNumber("Speed Cap",(this.differentialDriveTrain.getSpeedCap()));
 
         /*
+        Old code
         if(RobotController.getBatteryVoltage() <= lowerLimit || RobotController.isBrownedOut()) {
             if(isLiner){
                 this.differentialDriveTrain.setSpeedCap(this.differentialDriveTrain.getSpeedCap() - liner);

--- a/commands/Drivetrain/SmartArcadeDrive.java
+++ b/commands/Drivetrain/SmartArcadeDrive.java
@@ -29,7 +29,6 @@ Add connectivity b/x other parts
 
     @Override
     public void execute() {
-        
         this.divder = SmartDashboard.getNumber("Speed Divider", 11);
         if (SmartDashboard.getBoolean("Anit-Brownout mode",true)){
             this.differentialDriveTrain.setSpeedCap(RobotController.getBatteryVoltage()/divder);
@@ -38,23 +37,6 @@ Add connectivity b/x other parts
         }
  
         SmartDashboard.putNumber("Speed Cap",(this.differentialDriveTrain.getSpeedCap()));
-
-        /*
-        Old code
-        if(RobotController.getBatteryVoltage() <= lowerLimit || RobotController.isBrownedOut()) {
-            if(isLiner){
-                this.differentialDriveTrain.setSpeedCap(this.differentialDriveTrain.getSpeedCap() - liner);
-            } else {
-                this.differentialDriveTrain.setSpeedCap(this.differentialDriveTrain.getSpeedCap() * scaler);
-            }
-        } else if(RobotController.getBatteryVoltage() >= upperLimit) {
-            if(isLiner){
-                this.differentialDriveTrain.setSpeedCap(this.differentialDriveTrain.getSpeedCap() + liner);
-            } else {
-                this.differentialDriveTrain.setSpeedCap(this.differentialDriveTrain.getSpeedCap() / scaler);
-                }
-        }*/
-        
 
         this.differentialDriveTrain.getDifferentialDrive().arcadeDrive(-driveStick.getY(), driveStick.getX());
     }

--- a/commands/Drivetrain/SmartArcadeDrive.java
+++ b/commands/Drivetrain/SmartArcadeDrive.java
@@ -1,0 +1,62 @@
+package frc.robot.core751.commands.Drivetrain;
+
+import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.core751.subsystems.SmartDifferentialDriveTrain;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+public class SmartArcadeDrive extends CommandBase {
+
+    private Joystick driveStick;
+    private SmartDifferentialDriveTrain differentialDriveTrain;
+    private double divder;
+
+
+/*
+To do:
+
+Add connectivity b/x other parts
+
+*/
+
+    public SmartArcadeDrive(int port, SmartDifferentialDriveTrain differentialDriveTrain) {
+        this.driveStick = new Joystick(port);
+        this.differentialDriveTrain = differentialDriveTrain;
+        addRequirements(differentialDriveTrain);
+    }
+    
+
+    @Override
+    public void execute() {
+        
+        this.divder = SmartDashboard.getNumber("Speed Divider", 11);
+        if (SmartDashboard.getBoolean("Anit-Brownout mode",true)){
+            this.differentialDriveTrain.setSpeedCap(RobotController.getBatteryVoltage()/divder);
+        } else{
+            this.differentialDriveTrain.setSpeedCap( SmartDashboard.getNumber("Speed Cap Max", 0.9));
+        }
+ 
+        SmartDashboard.putNumber("Speed Cap",(this.differentialDriveTrain.getSpeedCap()));
+
+        /*
+        if(RobotController.getBatteryVoltage() <= lowerLimit || RobotController.isBrownedOut()) {
+            if(isLiner){
+                this.differentialDriveTrain.setSpeedCap(this.differentialDriveTrain.getSpeedCap() - liner);
+            } else {
+                this.differentialDriveTrain.setSpeedCap(this.differentialDriveTrain.getSpeedCap() * scaler);
+            }
+        } else if(RobotController.getBatteryVoltage() >= upperLimit) {
+            if(isLiner){
+                this.differentialDriveTrain.setSpeedCap(this.differentialDriveTrain.getSpeedCap() + liner);
+            } else {
+                this.differentialDriveTrain.setSpeedCap(this.differentialDriveTrain.getSpeedCap() / scaler);
+                }
+        }*/
+        
+
+        this.differentialDriveTrain.getDifferentialDrive().arcadeDrive(-driveStick.getY(), driveStick.getX());
+    }
+
+
+}

--- a/commands/Drivetrain/SpeedCapAdjuster.java
+++ b/commands/Drivetrain/SpeedCapAdjuster.java
@@ -1,0 +1,53 @@
+package frc.robot.core751.commands.Drivetrain;
+
+import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.core751.subsystems.SmartDifferentialDriveTrain;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+public class SpeedCapAdjuster extends CommandBase {
+
+    private Type type;
+    private boolean state = false; //Only used with switch
+    private SmartDifferentialDriveTrain differentialDriveTrain;
+    private double amount;
+
+    public static enum Type{//How it alters the Speed Cap
+        Switch,
+        Button
+    }
+
+    public SpeedCapAdjuster(SmartDifferentialDriveTrain differentialDriveTrain,int amount){
+        this(differentialDriveTrain,Type.Button,amount);
+    }
+
+    public SpeedCapAdjuster(SmartDifferentialDriveTrain differentialDriveTrain,Type type,int amount) {
+        this.differentialDriveTrain = differentialDriveTrain;
+        this.type = type;
+        this.amount = amount;
+        addRequirements(differentialDriveTrain);
+    }
+
+    @Override
+    public void execute() {
+        if(type == Type.Switch){
+            if(!state){
+                differentialDriveTrain.setSpeedCap(amount);
+                state = true;
+            } else {
+                differentialDriveTrain.setSpeedCap(SmartDashboard.getNumber("Speed Cap Max", 0.9));
+                state = false;
+            }
+        } else if(type == Type.Button){
+            differentialDriveTrain.setSpeedCap(amount);
+        }
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        if(type == Type.Button){
+            differentialDriveTrain.setSpeedCap(SmartDashboard.getNumber("Speed Cap Max", 0.9));
+        }
+    }
+
+}

--- a/subsystems/CappedSpeedControllerGroup.java
+++ b/subsystems/CappedSpeedControllerGroup.java
@@ -8,9 +8,7 @@
 package frc.robot.core751.subsystems;
 import edu.wpi.first.wpilibj.SpeedControllerGroup;
 import edu.wpi.first.wpilibj.SpeedController;
-/**
- * Add your docs here.
- */
+
 public class CappedSpeedControllerGroup extends SpeedControllerGroup{
 
 private double speedCap = 1;

--- a/subsystems/CappedSpeedControllerGroup.java
+++ b/subsystems/CappedSpeedControllerGroup.java
@@ -1,0 +1,40 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.core751.subsystems;
+import edu.wpi.first.wpilibj.SpeedControllerGroup;
+import edu.wpi.first.wpilibj.SpeedController;
+/**
+ * Add your docs here.
+ */
+public class CappedSpeedControllerGroup extends SpeedControllerGroup{
+
+private double speedCap = 1;
+
+    public CappedSpeedControllerGroup(SpeedController speedController,
+    SpeedController... speedControllers){
+        super(speedController,speedControllers);
+    }
+
+@Override
+public void set(double speed) {
+    if(speed < 0){
+        speed = Math.max(speed, -speedCap);
+    } else if(speed > 0){
+        speed = Math.min(speed,speedCap);
+    }
+    super.set(speed);
+}
+
+public double getSpeedCap() {
+    return speedCap;
+}
+
+public void setSpeedCap(double speedCap) {
+    this.speedCap = speedCap;
+}
+}

--- a/subsystems/SmartDifferentialDriveTrain.java
+++ b/subsystems/SmartDifferentialDriveTrain.java
@@ -80,7 +80,8 @@ public class SmartDifferentialDriveTrain extends SubsystemBase {
         rightGroup.setSpeedCap(cap);
     }
     public double getSpeedCap(){
-        return Math.min(leftGroup.getSpeedCap(),rightGroup.getSpeedCap());//in case they are somehow diffrent
+        return Math.min(leftGroup.getSpeedCap(),rightGroup.getSpeedCap());
+        //in case they are somehow diffrent
     }
 
 

--- a/subsystems/SmartDifferentialDriveTrain.java
+++ b/subsystems/SmartDifferentialDriveTrain.java
@@ -1,0 +1,87 @@
+package frc.robot.core751.subsystems;
+
+import com.revrobotics.CANSparkMaxLowLevel.MotorType;
+
+import edu.wpi.first.wpilibj.PWMVictorSPX;
+import edu.wpi.first.wpilibj.SpeedController;
+import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.core751.wrappers.WCANSparkMax;
+
+public class SmartDifferentialDriveTrain extends SubsystemBase {
+
+    public enum smartDriveMotor {
+        kSparkMaxBrushless,
+        kPWMVictorSPX,
+    }
+
+    private SpeedController[] leftArray;
+    private SpeedController[] rightArray;
+
+    private CappedSpeedControllerGroup leftGroup;
+    private CappedSpeedControllerGroup rightGroup;
+
+    private DifferentialDrive differentialDrive;
+
+    private static CappedSpeedControllerGroup arrayToGroup(SpeedController[] sp) {
+        //There has to be a better way to do this
+        switch(sp.length) {
+            case 4:
+                return new CappedSpeedControllerGroup(sp[0], sp[1], sp[2], sp[3]);
+            case 3:
+                return new CappedSpeedControllerGroup(sp[0], sp[1], sp[2]);
+            case 2:
+                return new CappedSpeedControllerGroup(sp[0], sp[1]);
+            default:
+                return new CappedSpeedControllerGroup(sp[0]);
+        }
+    }
+
+    public SmartDifferentialDriveTrain (int[] left, int[] right, smartDriveMotor dm) {
+        switch (dm) {
+            case kSparkMaxBrushless:
+                leftArray = new WCANSparkMax[left.length];
+                rightArray = new WCANSparkMax[right.length];
+                for (int i = 0; i < leftArray.length; i++) {
+                    leftArray[i] = new WCANSparkMax(left[i], MotorType.kBrushless);
+                }
+                for (int i = 0; i < rightArray.length; i++) {
+                    rightArray[i] = new WCANSparkMax(right[i], MotorType.kBrushless);
+                }
+            break;
+            case kPWMVictorSPX:
+                leftArray = new PWMVictorSPX[left.length];
+                rightArray = new PWMVictorSPX[right.length];
+                for (int i = 0; i < leftArray.length; i++) {
+                    leftArray[i] = new PWMVictorSPX(left[i]);
+                }
+                for (int i = 0; i < rightArray.length; i++) {
+                    rightArray[i] = new PWMVictorSPX(right[i]);
+                }
+            break;
+        }
+        this.leftGroup = arrayToGroup(leftArray);
+        this.rightGroup = arrayToGroup(rightArray);
+
+        this.differentialDrive = new DifferentialDrive(leftGroup, rightGroup);
+
+    }
+
+    public DifferentialDrive getDifferentialDrive() {
+        return this.differentialDrive;
+    }
+    public void setSpeedCap(double cap) {
+        if(cap > SmartDashboard.getNumber("Speed Cap Max", 0.9)){
+            cap = SmartDashboard.getNumber("Speed Cap Max", 0.9);
+        }
+        
+        leftGroup.setSpeedCap(cap);
+        rightGroup.setSpeedCap(cap);
+    }
+    public double getSpeedCap(){
+        return Math.min(leftGroup.getSpeedCap(),rightGroup.getSpeedCap());//in case they are somehow diffrent
+    }
+
+
+}


### PR DESCRIPTION
The code for protecting against brownouts. With the default(Divider:11, Speed Cap Max:0.9) it reduces at least 60% of the brownouts(During a 2:15 testing time). Higher divider will remove more brown outs but could result in the robot feeling slow. 